### PR TITLE
Update PelIfd.php

### DIFF
--- a/src/PelIfd.php
+++ b/src/PelIfd.php
@@ -424,7 +424,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
                         return $v;
 
                     case PelFormat::ASCII:
-                        return new PelEntryAscii($tag, $data->getBytes(0, - 1));
+                        return new PelEntryAscii($tag, $data->getBytes(0));
 
                     case PelFormat::SHORT:
                         $v = new PelEntryShort($tag);


### PR DESCRIPTION
This seems to fix the issue, we always take full size and let PHP strip the 0 terminator when returning from PelEntryAscii::getvalue()